### PR TITLE
Updating to use npm instead of calling gulp directly

### DIFF
--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -64,7 +64,7 @@ npm install
 Do an initial build of assets:
 
 ```
-gulp build
+npm run build
 ```
 
 


### PR DESCRIPTION
I believe that we have begun standardizing on building front-end assets by calling npm scripts directly. The README here assumes the user has gulp installed globally, calling `npm run build` accomplishes the same thing but uses the build script in package.json.

Just a thought, absolutely down to discuss. 