### PR TITLE
add django rq link to django admin by default

### DIFF
--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -193,3 +193,9 @@ heroku addons:create ssl:endpoint
 Follow the
 [SSL Endpoint documentation](https://devcenter.heroku.com/articles/ssl-endpoint)
 to upload the custom cert and finish configuration.
+
+## Operational Notes
+
+{% if cookiecutter.use_rq == 'y' -%}
+The setting `RQ_SHOW_ADMIN_LINK = True` tells django-rq to override the base django admin template. If your project wants to override the base admin template, you should disable this feature and add a link to django-rq yourself. [Documentation](https://github.com/ui/django-rq#queue-statistics)
+{%- endif %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings.py
@@ -130,6 +130,7 @@ RQ_QUEUES = {
         'URL': config('REDIS_URL', default='redis://localhost:6379/0'),
     },
 }
+RQ_SHOW_ADMIN_LINK = True
 {%- endif %}
 
 {% if cookiecutter.use_sentry == "y" -%}


### PR DESCRIPTION
this does override the django admin base template, so apps that want to override the template themselves should not use this
https://github.com/ui/django-rq#queue-statistics