### PR TITLE
Mo Static option

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,5 +10,6 @@
     "use_sentry": "y",
     "use_rq": "n",
     "use_redis": "{{ cookiecutter.use_rq }}",
-    "use_foundation_sites": "y"
+    "use_mo_static": "y",
+    "use_foundation_sites": "{{ cookiecutter.use_mo_static }}"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,78 @@
+from __future__ import print_function
+import os
+import shutil
+
+
+"""
+Inspired by the post generation file of
+https://github.com/pydanny/cookiecutter-django
+
+There are some other useful things they do, we might want to consider including
+"""
+
+
+# Get the root project directory
+PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
+
+
+MO_STATIC_FILES = [
+    '.babelrc', '.eslintrc', '.nvmrc', '.stylelintrc', 'banner.txt',
+    'gulpfile.babel.js', 'npm-shrinkwrap.json', 'package.json']
+
+
+DEFAULT_STATIC_FILES = ['app.js', 'app.css']
+
+
+def remove_file(file_name):
+    if os.path.exists(file_name):
+        os.remove(file_name)
+
+
+def update_static_dir(project_directory):
+    """Removes the README and adds blanks app.js and app.css"""
+    static_location = os.path.join(
+        PROJECT_DIRECTORY,
+        '{{ cookiecutter.package_name }}/static'
+    )
+
+    file_name = os.path.join(static_location, 'README.md')
+    remove_file(file_name)
+
+    for filename in DEFAULT_STATIC_FILES:
+        file_name = os.path.join(static_location, filename)
+        open(file_name, 'a')
+
+
+def remove_static_src_dir(project_directory):
+    """Removes the static_src directory"""
+
+    static_src_location = os.path.join(
+        PROJECT_DIRECTORY,
+        '{{ cookiecutter.package_name }}/static_src'
+    )
+    shutil.rmtree(static_src_location)
+
+
+def remove_mostatic_files():
+    """Removes the mo static frontend build files"""
+
+    for filename in MO_STATIC_FILES:
+        file_name = os.path.join(PROJECT_DIRECTORY, filename)
+        remove_file(file_name)
+
+    docs_dir_location = os.path.join(PROJECT_DIRECTORY, 'gulp')
+    if os.path.exists(docs_dir_location):
+        shutil.rmtree(docs_dir_location)
+
+
+if '{{ cookiecutter.use_mo_static }}'.lower() == 'n':
+    remove_mostatic_files()
+    update_static_dir(PROJECT_DIRECTORY)
+    remove_static_src_dir(PROJECT_DIRECTORY)
+
+
+# Display a warning if you include foundation sites and not mo static
+if '{{ cookiecutter.use_mo_static }}'.lower() == 'n' and '{{ cookiecutter.use_foundation_sites }}'.lower() == 'y':
+    print(
+        "You selected to use Foundation and didn't select to include Mo Static This is NOT supported out of the box for now."
+    )

--- a/{{cookiecutter.repo_name}}/Procfile.dev
+++ b/{{cookiecutter.repo_name}}/Procfile.dev
@@ -1,5 +1,7 @@
 web: PYTHONUNBUFFERED=True python manage.py runserver 0.0.0.0:$PORT
+{% if cookiecutter.use_mo_static == "y" -%}
 static: npm run dev
+{%- endif %}
 {% if cookiecutter.use_rq == "y" -%}
 rqworker: PYTHONUNBUFFERED=True python manage.py rqworkers high default low --autoreload True
 {%- endif %}

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -50,7 +50,7 @@ createdb {{ cookiecutter.package_name }}
 foreman run python manage.py migrate
 foreman run python manage.py createsuperuser
 ```
-
+{% if cookiecutter.use_mo_static == 'y' -%}
 ### Front End Tools
 
 Use [nvm](https://github.com/creationix/nvm) to install the correct version
@@ -66,7 +66,7 @@ Do an initial build of assets:
 ```
 npm run build
 ```
-
+{%- endif %}
 
 ## Running the Project
 

--- a/{{cookiecutter.repo_name}}/app.json
+++ b/{{cookiecutter.repo_name}}/app.json
@@ -12,9 +12,11 @@
     "heroku-postgresql:hobby-dev"
   ],
   "buildpacks": [
+    {% if cookiecutter.use_mo_static == "y" -%}
     {
       "url": "heroku/nodejs"
     },
+    {%- endif %}
     {
       "url": "heroku/python"
     }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/templates/base.html
@@ -27,7 +27,6 @@
         <meta name="twitter:title" content="">
         <meta name="twitter:description" content="">
         <meta name="twitter:image" content="">
-
         <link rel="stylesheet" href="{% static 'css/app.css' %}">
         <script src="{% static 'js/bundle.js' %}" async defer></script>
     </head>


### PR DESCRIPTION
If Mo Static is not selected this removes the following files '.babelrc', '.eslintrc', '.nvmrc', '.stylelintrc', 'banner.txt', 'gulpfile.babel.js', 'npm-shrinkwrap.json', 'package.json'. and the static_src directory.
As well as the the Heroku Node buildpack.
Does include `static: npm run dev` in the Procfile.dev

Last it copies a blank app.css and app.js into the static directory.
