### PR TITLE
Fix to setup manual install

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/settings.py
@@ -61,6 +61,7 @@ if DEBUG and config('DEBUG_TOOLBAR', default=True, cast=bool):
     MIDDLEWARE.append(
         'debug_toolbar.middleware.DebugToolbarMiddleware')
 
+INTERNAL_IPS = '127.0.0.1'
 
 ROOT_URLCONF = '{{ cookiecutter.package_name }}.urls'
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/urls.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 
@@ -14,3 +15,9 @@ urlpatterns = [
 
     url(r'^admin/', include(admin.site.urls)),
 ]
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns


### PR DESCRIPTION
Automatic install was removed in version 1.6
http://django-debug-toolbar.readthedocs.io/en/1.7/changes.html#removed-features